### PR TITLE
Fix raw type usage

### DIFF
--- a/src/main/java/botty/commands/DeleteCommand.java
+++ b/src/main/java/botty/commands/DeleteCommand.java
@@ -2,6 +2,7 @@ package botty.commands;
 
 import botty.exceptions.BottyException;
 import botty.tasks.Task;
+import botty.tasks.TaskData;
 import botty.tasks.TaskManager;
 
 /**
@@ -21,7 +22,7 @@ public class DeleteCommand extends Command {
             String argument = parsedInput.getArgument("main");
             int taskIndex = Integer.parseInt(argument) - 1;
 
-            Task task = taskManager.deleteTask(taskIndex);
+            Task<? extends TaskData> task = taskManager.deleteTask(taskIndex);
             return "Got it! I have removed the following task:\n"
                     + task + "\n"
                     + "You have " + taskManager.size() + " tasks left!";

--- a/src/main/java/botty/commands/MarkCommand.java
+++ b/src/main/java/botty/commands/MarkCommand.java
@@ -2,6 +2,7 @@ package botty.commands;
 
 import botty.exceptions.BottyException;
 import botty.tasks.Task;
+import botty.tasks.TaskData;
 import botty.tasks.TaskManager;
 
 /**
@@ -21,7 +22,7 @@ public class MarkCommand extends Command {
             String argument = parsedInput.getArgument("main");
 
             int taskIndex = Integer.parseInt(argument) - 1;
-            Task task = taskManager.markTask(taskIndex);
+            Task<? extends TaskData> task = taskManager.markTask(taskIndex);
 
             return "Congrats on completing that! Let me just mark that as done for you.\n" + task;
         } catch (NumberFormatException ex) {

--- a/src/main/java/botty/commands/UnmarkCommand.java
+++ b/src/main/java/botty/commands/UnmarkCommand.java
@@ -2,6 +2,7 @@ package botty.commands;
 
 import botty.exceptions.BottyException;
 import botty.tasks.Task;
+import botty.tasks.TaskData;
 import botty.tasks.TaskManager;
 
 /**
@@ -22,7 +23,7 @@ public class UnmarkCommand extends Command {
             String argument = parsedInput.getArgument("main");
 
             int taskIndex = Integer.parseInt(argument) - 1;
-            Task task = taskManager.unmarkTask(taskIndex);
+            Task<? extends TaskData> task = taskManager.unmarkTask(taskIndex);
 
             return "It's okay, we can get that done later. I'll mark that as undone for you.\n" + task;
         } catch (NumberFormatException ex) {

--- a/src/main/java/botty/tasks/TaskManager.java
+++ b/src/main/java/botty/tasks/TaskManager.java
@@ -91,6 +91,7 @@ public class TaskManager {
      * @param task the task to be added
      */
     public void addTask(Task<? extends TaskData> task) {
+        assert task != null : "Cannot add a null task";
         taskList.add(task);
     }
 


### PR DESCRIPTION
Replace raw type usage `Task task` with bounded wildcard `Task<? extends TaskData> task` to eliminate warnings